### PR TITLE
bumping verisons and fixing incompatible package imports

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -4,7 +4,7 @@ version := "0.0.1"
 
 organization := "$package$"
 
-scalaVersion := "2.9.1"
+scalaVersion := "2.10.2"
 
 resolvers ++= Seq("snapshots"     at "http://oss.sonatype.org/content/repositories/snapshots",
                 "releases"        at "http://oss.sonatype.org/content/repositories/releases"
@@ -17,8 +17,9 @@ scalacOptions ++= Seq("-deprecation", "-unchecked")
 libraryDependencies ++= {
   val liftVersion = "2.5-SNAPSHOT"
   Seq(
-    "net.liftweb"       %% "lift-webkit"        % liftVersion        % "compile",
-    "net.liftmodules"   %% "lift-jquery-module" % (liftVersion + "-1.0-SNAPSHOT"),
+    "net.liftweb"       %% "lift-webkit"        % "2.6-SNAPSHOT",
+    "net.liftweb"       %% "lift-testkit"        % "2.6-SNAPSHOT",
+    "net.liftmodules"   %% "lift-jquery-module" % (liftVersion + "-2.1-SNAPSHOT"),
     "org.eclipse.jetty" % "jetty-webapp"        % "7.5.4.v20111024"  % "container; test",
     "ch.qos.logback"    % "logback-classic"     % "1.0.6",
     "org.specs2"        %% "specs2"             % "1.11"             % "test"


### PR DESCRIPTION
Couldn't get your template to work out of the box -- and this fixes it, and also brings everything to the latest version of lift 2.5 (and I guess 2.6 for some packages -- I'm a bit new to lift). 
